### PR TITLE
Support NX-OS and OpenShift compatible Dockerfile

### DIFF
--- a/docker/Kuberfile
+++ b/docker/Kuberfile
@@ -9,20 +9,14 @@
 # OpenShift where there are security implications.
 # ----------------------------------------------------
 
-FROM phusion/baseimage:v0.9.22
+FROM bitnami/minideb:latest
 
 MAINTAINER Remington Campbell <remcampb@cisco.com>
-
-# Use baseimage-docker's init system.
-CMD ["/sbin/my_init"]
 
 VOLUME ["/data"]
 VOLUME ["/data/config"]
 
 ADD pipeline /data/pipeline
-
-RUN mkdir /etc/service/pipeline
-ADD pipeline.sh /etc/service/pipeline/run
-
-# Clean up APT when done.
-# RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+WORKDIR /data
+ENTRYPOINT ["pipeline"]
+CMD ["-log=pipeline.log", "-config=config/pipeline.conf", "-pem=config/pipeline_rsa"]

--- a/docker/Kuberfile
+++ b/docker/Kuberfile
@@ -4,9 +4,10 @@
 #
 # Assumes the fully configured configurations will be supplied
 # in Kubernetes as a ConfigMap to /data/config
-# pipeline is now placed in /data in order to allow the create/delete
-# of other files which is otherwise not allowed by platforms such as
-# OpenShift where there are security implications.
+# pipeline is placed in / (root) but workdir is set to /data volume
+# in order to allow the create/delete of other files like models.txt
+# which is otherwise not allowed by platforms such as OpenShift
+# where there are security restrictions by default on permissions.
 # ----------------------------------------------------
 
 FROM bitnami/minideb:latest

--- a/docker/Kuberfile
+++ b/docker/Kuberfile
@@ -18,5 +18,5 @@ VOLUME ["/data/config"]
 
 ADD pipeline /data/pipeline
 WORKDIR /data
-ENTRYPOINT ["pipeline"]
+ENTRYPOINT ["./pipeline"]
 CMD ["-log=pipeline.log", "-config=config/pipeline.conf", "-pem=config/pipeline_rsa"]

--- a/docker/Kuberfile
+++ b/docker/Kuberfile
@@ -18,5 +18,5 @@ VOLUME ["/data/config"]
 
 ADD pipeline /data/pipeline
 WORKDIR /data
-ENTRYPOINT ["./pipeline"]
-CMD ["-log=pipeline.log", "-config=config/pipeline.conf", "-pem=config/pipeline_rsa"]
+ENTRYPOINT ["/data/pipeline"]
+CMD ["-log=/data/pipeline.log", "-config=/data/config/pipeline.conf", "-pem=/data/config/pipeline_rsa"]

--- a/docker/Kuberfile
+++ b/docker/Kuberfile
@@ -16,11 +16,12 @@ MAINTAINER Remington Campbell <remcampb@cisco.com>
 # Use baseimage-docker's init system.
 CMD ["/sbin/my_init"]
 
+# Create ConfigMap directory, /data for consistency.
 VOLUME ["/data"]
-VOLUME ["/data/config"]
 
-ADD pipeline /data/pipeline
-
+# Add the pipeline executable
+ADD pipeline /usr/bin/pipeline
+# Add the runit script to execute pipeline
 RUN mkdir /etc/service/pipeline
 ADD pipeline.sh /etc/service/pipeline/run
 

--- a/docker/Kuberfile
+++ b/docker/Kuberfile
@@ -1,0 +1,28 @@
+# How to build?
+#
+# docker build -f ./Kuberfile -t pipeline:<version> .
+#
+# Assumes the fully configured configurations will be supplied
+# in Kubernetes as a ConfigMap to /data/config
+# pipeline is now placed in /data in order to allow the create/delete
+# of other files which is otherwise not allowed by platforms such as
+# OpenShift where there are security implications.
+# ----------------------------------------------------
+
+FROM phusion/baseimage:v0.9.22
+
+MAINTAINER Remington Campbell <remcampb@cisco.com>
+
+# Use baseimage-docker's init system.
+CMD ["/sbin/my_init"]
+
+VOLUME ["/data"]
+VOLUME ["/data/config"]
+
+ADD pipeline /data/pipeline
+
+RUN mkdir /etc/service/pipeline
+ADD pipeline.sh /etc/service/pipeline/run
+
+# Clean up APT when done.
+# RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/docker/Kuberfile
+++ b/docker/Kuberfile
@@ -16,7 +16,7 @@ MAINTAINER Remington Campbell <remcampb@cisco.com>
 VOLUME ["/data"]
 VOLUME ["/data/config"]
 
-ADD pipeline /data/pipeline
+ADD pipeline /pipeline
 WORKDIR /data
-ENTRYPOINT ["/data/pipeline"]
+ENTRYPOINT ["/pipeline"]
 CMD ["-log=/data/pipeline.log", "-config=/data/config/pipeline.conf", "-pem=/data/config/pipeline_rsa"]

--- a/docker/pipeline.sh
+++ b/docker/pipeline.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# `/sbin/setuser pipeline` runs the given command as the user `pipeline`.
+# If you omit that part, the command will be run as root.
+exec /sbin/setuser pipeline /usr/bin/pipeline -log=/data/pipeline.log -config=/data/pipeline.conf -pem=/data/pipeline_rsa

--- a/docker/pipeline.sh
+++ b/docker/pipeline.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-# `/sbin/setuser pipeline` runs the given command as the user `pipeline`.
-# If you omit that part, the command will be run as root.
-exec /sbin/setuser pipeline /usr/bin/pipeline -log=/data/pipeline.log -config=/data/pipeline.conf -pem=/data/pipeline_rsa

--- a/xport_grpc.go
+++ b/xport_grpc.go
@@ -464,13 +464,13 @@ func (s *grpcLocalServer) MdtDialout(
 		reply, err := stream.Recv()
 		if err != nil {
 			if err == io.EOF {
-				logctx.WithError(err).Error(GRPCLOGPRE +
-					"session closed")
+				//logctx.WithError(err).Error(GRPCLOGPRE +
+				//	"session closed")
 			} else {
 				logctx.WithError(err).Error(GRPCLOGPRE +
 					"session error")
 			}
-			return err
+			return nil
 		}
 
 		if len(reply.Data) == 0 {


### PR DESCRIPTION
## Add Kubernetes/OpenShift compatible Dockerfile (Kuberfile)
Add a Dockerfile which assumes that configuration will be applied as a ConfigMap to /data/config.
Assumes that logs, or other generated files by Pipeline will go in to /data.
Resolves OpenShift incompatibility with permissions on read/write to folders which are not volumes, hence a volume for Pipeline storage and another volume to map to configuration.

## Enable NX-OS MDT consumption
Removes EOF error as NX-OS sends an EOF, IOS XR does not thus pipeline errors as it checks this condition. Implications unknown.

Recommend squash merge, did not branch. 👎 