### PR TITLE
make fails w/ go vet -- added fmt.Sprintf to accommodate string formatting directives

### DIFF
--- a/metrics_prometheus.go
+++ b/metrics_prometheus.go
@@ -75,7 +75,7 @@ func (p *metricsPrometheusOutputHandler) flushMetric(
 	})
 
 	if buf.Len() == 0 {
-		logCtx.Debug("metrics export (no metrics in msg): keys [%v]", tags)
+		logCtx.Debug(fmt.Sprintf("metrics export (no metrics in msg): keys [%v]", tags))
 		return
 	}
 

--- a/xport_grpc_test.go
+++ b/xport_grpc_test.go
@@ -112,7 +112,7 @@ func TestGRPCRun(t *testing.T) {
 	}
 	log.Debug("       END       ==============================================")
 
-	log.Debug("GRPCTEST: exited datachannel after %d events\n", i)
+	log.Debug(fmt.Sprintf("GRPCTEST: exited datachannel after %d events\n", i))
 	respChan := make(chan *ctrlMsg)
 	request := &ctrlMsg{
 		id:       SHUTDOWN,


### PR DESCRIPTION
```
bigmuddy-network-telemetry-pipeline $make
go vet bigmuddy-network-telemetry-pipeline bigmuddy-network-telemetry-pipeline/mdt_msg_samples
# bigmuddy-network-telemetry-pipeline
./metrics_prometheus.go:78:3: Debug call has possible formatting directive %v
./xport_grpc_test.go:115:2: Debug call has possible formatting directive %d
make: *** [bin/pipeline] Error 2
```